### PR TITLE
feat: 로그아웃 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
+	//Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	//test lombok
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/tuk/sportify/member/controller/MemberController.java
+++ b/src/main/java/com/tuk/sportify/member/controller/MemberController.java
@@ -7,12 +7,16 @@ import com.tuk.sportify.member.dto.LoginMemberRequest;
 import com.tuk.sportify.member.dto.MemberInfoResponse;
 import com.tuk.sportify.member.exception.EmptyMemberListException;
 import com.tuk.sportify.member.exception.MemberNotFoundException;
+import com.tuk.sportify.member.jwt.ApiResponseJson;
 import com.tuk.sportify.member.jwt.token.dto.TokenInfo;
+import com.tuk.sportify.member.principle.UserPrinciple;
 import com.tuk.sportify.member.service.MemberService;
 import com.tuk.sportify.member.service.mapper.MemberMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -41,6 +45,18 @@ public class MemberController {
         log.info("Token issued: {}", tokenInfo);
 
         return tokenInfo; // TokenInfo DTO 직접 반환
+    }
+
+    @PostMapping("/logout")
+    public ApiResponseJson logout(@AuthenticationPrincipal UserPrinciple userPrinciple, @RequestHeader("Authorization") String authHeader) {
+        String email = userPrinciple.getEmail();
+
+        log.info("로그아웃 이메일: {}", email);
+
+        // Bearer 를 문자열에서 제외하기 위해 substring을 사용
+        memberService.logoutMember(authHeader.substring(7), email);
+
+        return new ApiResponseJson(HttpStatus.OK, "로그아웃 성공");
     }
 
     // 모든 회원 조회

--- a/src/main/java/com/tuk/sportify/member/jwt/AccessTokenBlackList.java
+++ b/src/main/java/com/tuk/sportify/member/jwt/AccessTokenBlackList.java
@@ -1,0 +1,35 @@
+package com.tuk.sportify.member.jwt;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AccessTokenBlackList {
+    private final RedisTemplate<String, Object> redisBlackListTemplate;
+
+    @Value("${jwt.access-token-validity-in-seconds}")
+    private Long accessTokenTimeoutInSeconds;
+
+    public void setBlackList(String key, Object o) {
+        //Jackson2JsonRedisSerializer를 사용하여 객체 -> JSON(직렬화)
+        redisBlackListTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(o.getClass()));
+        //주어진 key, value를 redis에 저장하고 만료시간 설정
+        redisBlackListTemplate.opsForValue().set(key, o, accessTokenTimeoutInSeconds * 1000, TimeUnit.MILLISECONDS);
+    }
+
+    public Object getBlackList(String key) {
+        return redisBlackListTemplate.opsForValue().get(key);
+    }
+
+    public boolean isTokenBlackList(String key) {
+        return Boolean.TRUE.equals(redisBlackListTemplate.hasKey(key));
+    }
+}

--- a/src/main/java/com/tuk/sportify/member/jwt/JwtConfig.java
+++ b/src/main/java/com/tuk/sportify/member/jwt/JwtConfig.java
@@ -10,9 +10,12 @@ import org.springframework.context.annotation.Configuration;
 @RequiredArgsConstructor
 @EnableConfigurationProperties(JwtProperties.class)
 public class JwtConfig {
+
+    private final AccessTokenBlackList accessTokenBlackList;
+
     @Bean
     public TokenProvider tokenProvider(JwtProperties jwtProperties) {
-        return new TokenProvider(jwtProperties.getSecret(), jwtProperties.getAccessTokenValidityInSeconds());
+        return new TokenProvider(jwtProperties.getSecret(), jwtProperties.getAccessTokenValidityInSeconds(), accessTokenBlackList);
     }
 
     @Bean

--- a/src/main/java/com/tuk/sportify/member/jwt/SecurityConfig.java
+++ b/src/main/java/com/tuk/sportify/member/jwt/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
 
     //권한별 url
     private final String[] adminUrl = {"/admin/**"};
-    private final String[] permitAllUrl = {"/error", "/members/login"};
+    private final String[] permitAllUrl = {"/error", "/members/login", "/members/logout"};
     private final String[] anonymousUrl = {"/members/**"};
 
 

--- a/src/main/java/com/tuk/sportify/member/jwt/token/TokenProvider.java
+++ b/src/main/java/com/tuk/sportify/member/jwt/token/TokenProvider.java
@@ -1,6 +1,7 @@
 package com.tuk.sportify.member.jwt.token;
 
 import com.tuk.sportify.member.domain.Member;
+import com.tuk.sportify.member.jwt.AccessTokenBlackList;
 import com.tuk.sportify.member.jwt.token.dto.TokenInfo;
 import com.tuk.sportify.member.jwt.token.dto.TokenValidationResult;
 import com.tuk.sportify.member.principle.UserPrinciple;
@@ -28,11 +29,13 @@ public class TokenProvider {
 
     private final Key hashKey;
     private final long accessTokenValidationInMilliseconds;
+    private final AccessTokenBlackList accessTokenBlackList;
 
-    public TokenProvider(String secrete, long accessTokenValidationInSeconds) {
-        byte[] keyBytes = Decoders.BASE64.decode(secrete);
+    public TokenProvider(String key, long accessTokenValidationInSeconds, AccessTokenBlackList accessTokenBlackList) {
+        byte[] keyBytes = Decoders.BASE64.decode(key);
         this.hashKey = Keys.hmacShaKeyFor(keyBytes);
         this.accessTokenValidationInMilliseconds = accessTokenValidationInSeconds * 1000;
+        this.accessTokenBlackList = accessTokenBlackList;
     }
 
     //토큰 생성
@@ -98,6 +101,14 @@ public class TokenProvider {
         UserPrinciple principle = new UserPrinciple(claims.getSubject(), claims.get(USERNAME_KEY, String.class), authorities,claims.get(ID,Long.class));
 
         return new UsernamePasswordAuthenticationToken(principle, token, authorities);
+    }
+
+    public boolean isAccessTokenBlackList(String accessToken) {
+        if (accessTokenBlackList.isTokenBlackList(accessToken)) {
+            log.info("BlackListed Access Token");
+            return true;
+        }
+        return false;
     }
 }
 

--- a/src/main/java/com/tuk/sportify/member/principle/UserPrinciple.java
+++ b/src/main/java/com/tuk/sportify/member/principle/UserPrinciple.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 @Getter
 public class UserPrinciple extends User{
     private static final String PASSWORD_ERASED_VALUE = "[PASSWORD_ERASED]";
-    final String email;
+    private final String email;
     final Long memberId;
 
     public UserPrinciple(String email, String username, Collection<? extends GrantedAuthority> authorities, Long memberId) {

--- a/src/main/java/com/tuk/sportify/member/redis/RedisConfig.java
+++ b/src/main/java/com/tuk/sportify/member/redis/RedisConfig.java
@@ -1,0 +1,40 @@
+package com.tuk.sportify.member.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String redisPassword;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        //0~15 중 DB 선택 가능함. 기본은 0.
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(redisPassword);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/tuk/sportify/member/service/MemberService.java
+++ b/src/main/java/com/tuk/sportify/member/service/MemberService.java
@@ -7,6 +7,7 @@ import com.tuk.sportify.member.dto.MemberInfoResponse;
 import com.tuk.sportify.member.exception.LoginFailedException;
 import com.tuk.sportify.member.exception.MemberNotFoundException;
 import com.tuk.sportify.member.exception.RegisterFailedException;
+import com.tuk.sportify.member.jwt.AccessTokenBlackList;
 import com.tuk.sportify.member.jwt.token.TokenProvider;
 import com.tuk.sportify.member.jwt.token.dto.TokenInfo;
 import com.tuk.sportify.member.repository.MemberRepository;
@@ -37,6 +38,7 @@ public class MemberService {
     private final MemberMapper memberMapper;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
+    private final AccessTokenBlackList accessTokenBlackList;
 
     public Member createMember(CreateMemberRequest request) {
         checkPasswordStrength(request.password());
@@ -71,6 +73,10 @@ public class MemberService {
         } catch (BadCredentialsException e) {
             throw new LoginFailedException(ErrorCode.MEMBER_LOGIN_PASSWORD_INCORRECT);
         }
+    }
+
+    public void logoutMember(String accessToken, String email) {
+        accessTokenBlackList.setBlackList(accessToken, email);
     }
 
     private void checkPassword(String password, Member member) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,8 +8,3 @@ spring:
       local: local, vworld
       dev:
       prod:
-
-jwt:
-  header: Authorization
-  secret: dGhpcyBpcyBteSBoaWRkZW4gand0IGtleSBmb3IgdGVzdCwgcGxlYXNlIGdpdmUgbWUgand0IGtleSBoYWhhaGFoYWhh==
-  access-token-validity-in-seconds: 360000


### PR DESCRIPTION
redis 설치 후 application-local.yml에

spring:
  data:
      redis:
        host: localhost
        port: 6379
        password:

jwt:
  header: Authorization
  secret: dGhpcyBpcyBteSBoaWRkZW4gand0IGtleSBmb3IgdGVzdCwgcGxlYXNlIGdpdmUgbWUgand0IGtleSBoYWhhaGFoYWhh==
  access-token-validity-in-seconds: 360000

추가하시면 됩니다.


회원가입
![image](https://github.com/user-attachments/assets/56b26aa3-a3cf-468d-a8cb-d9ff352b60eb)

로그인
![image](https://github.com/user-attachments/assets/10cde973-0751-4811-ad35-156502e85362)

로그아웃(accessToken post)
![image](https://github.com/user-attachments/assets/1c7b0fd6-0e6d-4b39-83bc-c4646bd25e80)

로그아웃 시 redis (blacklist에 저장되어 토큰 만료)
![image](https://github.com/user-attachments/assets/a4509767-930c-4b07-bf74-02e1a3e9c381)

